### PR TITLE
Hotfix: Incremental builds now correctly cache plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"gatsby-plugin-netlify": "^2.3.2",
 		"gatsby-plugin-react-helmet": "^3.1.2",
 		"gatsby-plugin-sitemap": "^2.4.2",
+		"netlify-plugin-gatsby-cache": "^0.2.1",
 		"react": "^16.8.6",
 		"react-dom": "npm:@hot-loader/react-dom",
 		"react-helmet": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7975,6 +7975,11 @@ neo-async@^2.5.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
+netlify-plugin-gatsby-cache@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/netlify-plugin-gatsby-cache/-/netlify-plugin-gatsby-cache-0.2.1.tgz#22d8ef9a9b022909ac3e330734a3362d11bef1c6"
+  integrity sha512-y5gSjDXPWyj/Hdjp3WEGWjpeBH5nCnqztgF45JIK3/xVQBH4vwurOUsoK6C9500d7z2/CNH6I9k01crIA81pMw==
+
 newline-regex@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/newline-regex/-/newline-regex-0.2.1.tgz#4696d869045ee1509b83aac3a58d4a93bbed926e"


### PR DESCRIPTION
Based on information [here](https://community.netlify.com/t/netlify-plugins-with-netlify-plugin-gatsby-cache-increases-build-time-not-reduce/14538/3). Adding `netlify-plugin-gatsby-cache` to `package.json` as a required dependency fixes build time bloat.

Looks like potential future version may make this redundant: [Netlify issue](https://github.com/netlify/build/issues/1137)